### PR TITLE
Allow to specify the format the phrases are downloaded in

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ After you have configured your build.gradle file, simply run: **gradle [taskname
 	<tr>
     	<td>fileFormat</td>
     	<td>properties</td>
-    	<td>The file format you want to download the messages keys.[properties,xml]</td>
+    	<td>The file extension you want to download the messages keys.[properties,xml,json,...]</td>
+    </tr>
+	<tr>
+    	<td>format</td>
+    	<td>properties</td>
+    	<td>The file format you want to download the messages keys in.[properties,xml,i18next,...]</td>
     </tr>
 </table>
 * these properties are required!!!

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin helps you to sync your externalized/internationalized messages with 
     apply plugin: 'de.esailors.gradle.plugins.phraseapp'
 
     phraseAppSettings {
-        projectId = "123456789-your-project-id"˘
+        projectId = "123456789-your-project-id"
         authToken = "987654321-your-auth-token"
     }
 
@@ -76,12 +76,12 @@ After you have configured your build.gradle file, simply run: **gradle [taskname
 	<tr>
     	<td>fileFormat</td>
     	<td>properties</td>
-    	<td>The file extension you want to download the messages keys.[properties,xml,json,...]</td>
+    	<td>The file extension you want to download the messages keys.[properties,xml,...]</td>
     </tr>
 	<tr>
     	<td>format</td>
     	<td>properties</td>
-    	<td>The file format you want to download the messages keys in.[properties,xml,i18next,...]</td>
+    	<td>The file format you want to download the messages keys in.[properties,xml,...]</td>
     </tr>
 </table>
 * these properties are required!!!

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     compile 'com.mytaxi.apis:phrase-java-client:1.0.1'
     compile 'org.springframework:spring-web:3.2.15.RELEASE'
     testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:2.15.0'
 }
 
 // custom tasks for creating source/javadoc jars

--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,8 @@ allprojects {
     targetCompatibility = 1.8
 }
 
-
 group = 'de.esailors.gradle.plugins'
-version = '1.0.2'
+version = '1.0.3'
 description = 'Synchronizing your PhraseApp strings for a configured project.'
 
 println("Building  ${project.name} in version: ${project.version}.")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 14 17:53:52 CET 2016
+#Fri Mar 02 21:32:07 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip

--- a/src/main/java/de/esailors/gradle/plugins/phraseapp/PhraseAppDownloader.java
+++ b/src/main/java/de/esailors/gradle/plugins/phraseapp/PhraseAppDownloader.java
@@ -28,6 +28,12 @@ public class PhraseAppDownloader {
     }
 
     public void download() {
+        configure();
+
+        phraseAppSyncTask.run();
+    }
+
+    private void configure() {
         String destinationDir = phraseAppExtension.getDestinationDir();
         phraseAppSyncTask.setGeneratedResourcesFoldername(destinationDir);
         LOG.debug("Config: Destination is configured(else DEFAULT) - " + destinationDir);

--- a/src/main/java/de/esailors/gradle/plugins/phraseapp/PhraseAppDownloader.java
+++ b/src/main/java/de/esailors/gradle/plugins/phraseapp/PhraseAppDownloader.java
@@ -1,0 +1,56 @@
+package de.esailors.gradle.plugins.phraseapp;
+
+import com.mytaxi.apis.phrase.api.format.JavaPropertiesFormat;
+import com.mytaxi.apis.phrase.tasks.PhraseAppSyncTask;
+import de.esailors.gradle.plugins.phraseapp.extension.PhraseAppExtension;
+import de.esailors.gradle.plugins.phraseapp.format.OptionlessFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+public class PhraseAppDownloader {
+
+    private Logger LOG = LoggerFactory.getLogger(PhraseAppDownloader.class);
+
+    private PhraseAppExtension phraseAppExtension;
+    PhraseAppSyncTask phraseAppSyncTask;
+
+    public PhraseAppDownloader(PhraseAppExtension phraseAppExtension) {
+        this(phraseAppExtension, new PhraseAppSyncTask(phraseAppExtension.getAuthToken(), phraseAppExtension.getProjectId()));
+    }
+
+    public PhraseAppDownloader(PhraseAppExtension phraseAppExtension, PhraseAppSyncTask phraseAppSyncTask) {
+        Objects.requireNonNull(phraseAppExtension);
+
+        this.phraseAppExtension = phraseAppExtension;
+        this.phraseAppSyncTask = phraseAppSyncTask;
+    }
+
+    public void download() {
+        String destinationDir = phraseAppExtension.getDestinationDir();
+        phraseAppSyncTask.setGeneratedResourcesFoldername(destinationDir);
+        LOG.debug("Config: Destination is configured(else DEFAULT) - " + destinationDir);
+
+        String messagesFolderName = phraseAppExtension.getDestinationMessagesDir();
+        LOG.debug("Config: MessageFolderName is configured - " + messagesFolderName);
+        phraseAppSyncTask.setMessagesFoldername(messagesFolderName);
+
+        String messageFilePrefix = phraseAppExtension.getMessageFilePrefix();
+        LOG.debug("Config: MessageFilePrefix is configured - " + messageFilePrefix);
+        phraseAppSyncTask.setMessageFilePrefix(messageFilePrefix);
+
+        // TODO - update Client Impl
+        String messageFilePostfix = "." + phraseAppExtension.getFileFormat();
+        LOG.debug("Config: MessageFilePostfix is configured - " + messageFilePostfix);
+        phraseAppSyncTask.setMessageFilePostfix(messageFilePostfix);
+
+        String format = phraseAppExtension.getFormat();
+        LOG.debug("Config: format is configured - " + format);
+        if (JavaPropertiesFormat.NAME.equals(format)) {
+            phraseAppSyncTask.setFormat(JavaPropertiesFormat.newBuilder().build());
+        } else {
+            phraseAppSyncTask.setFormat(new OptionlessFormat(format));
+        }
+    }
+}

--- a/src/main/java/de/esailors/gradle/plugins/phraseapp/extension/PhraseAppExtension.java
+++ b/src/main/java/de/esailors/gradle/plugins/phraseapp/extension/PhraseAppExtension.java
@@ -82,7 +82,7 @@ public class PhraseAppExtension {
     public void validate() {
         LOG.debug("Validate configuration ..");
         if (!isValid()) {
-            LOG.error("Validation failed because of an invalid configuration: %s", this.toString());
+            LOG.error("Validation failed because of an invalid configuration: {}", this.toString());
             throw new IllegalArgumentException("Configuration is not valid!");
         }
         LOG.debug(".. validation of configuration successfully done!");

--- a/src/main/java/de/esailors/gradle/plugins/phraseapp/extension/PhraseAppExtension.java
+++ b/src/main/java/de/esailors/gradle/plugins/phraseapp/extension/PhraseAppExtension.java
@@ -59,12 +59,20 @@ public class PhraseAppExtension {
     private String messageFilePrefix = "messages_";
 
     /**
-     * The file format you want to download the messages keys.
+     * The file extension you want to download the messages keys.
      * <p>
      * [Optional]
      * Default: properties
      */
     private String fileFormat = "properties";
+
+    /**
+     * The format you want to download the messages keys. The file extension (see the fileFormat key) must match this
+     * format, which is, however, not enforced.
+     * [Optional]
+     * Default: properties
+     */
+    private String format = "properties";
 
 
     public boolean isValid() {

--- a/src/main/java/de/esailors/gradle/plugins/phraseapp/format/OptionlessFormat.java
+++ b/src/main/java/de/esailors/gradle/plugins/phraseapp/format/OptionlessFormat.java
@@ -1,0 +1,26 @@
+package de.esailors.gradle.plugins.phraseapp.format;
+
+import com.mytaxi.apis.phrase.api.format.Format;
+import org.apache.http.NameValuePair;
+
+import java.util.Collections;
+import java.util.List;
+
+public class OptionlessFormat implements Format {
+
+    private String formatName;
+
+    public OptionlessFormat(String formatName) {
+        this.formatName = formatName;
+    }
+
+    @Override
+    public String getName() {
+        return formatName;
+    }
+
+    @Override
+    public List<NameValuePair> getOptions() {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/de/esailors/gradle/plugins/phraseapp/tasks/DownloadTask.java
+++ b/src/main/java/de/esailors/gradle/plugins/phraseapp/tasks/DownloadTask.java
@@ -1,7 +1,6 @@
 package de.esailors.gradle.plugins.phraseapp.tasks;
 
-import com.mytaxi.apis.phrase.api.format.JavaPropertiesFormat;
-import com.mytaxi.apis.phrase.tasks.PhraseAppSyncTask;
+import de.esailors.gradle.plugins.phraseapp.PhraseAppDownloader;
 import de.esailors.gradle.plugins.phraseapp.extension.PhraseAppExtension;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
@@ -25,34 +24,9 @@ public class DownloadTask extends DefaultTask {
         settings.validate();
 
         LOG.info("Start DownloadTask for PhraseApp project with Id: %s ...", settings.getProjectId());
-        PhraseAppSyncTask phraseAppSyncTask = new PhraseAppSyncTask(settings.getAuthToken(), settings.getProjectId());
-        configure(phraseAppSyncTask, settings);
-        phraseAppSyncTask.run();
+        PhraseAppDownloader downloader = new PhraseAppDownloader(settings);
+        downloader.download();
         LOG.info("... finished DownloadTask for PhraseApp project with Id: $s !!!", settings.getProjectId());
-    }
-
-    private void configure(PhraseAppSyncTask phraseAppSyncTask, PhraseAppExtension settings) {
-        String destinationDir = settings.getDestinationDir();
-        phraseAppSyncTask.setGeneratedResourcesFoldername(destinationDir);
-        LOG.debug("Config: Destination is configured(else DEFAULT) - " + destinationDir);
-
-        String messagesFolderName = settings.getDestinationMessagesDir();
-        LOG.debug("Config: MessageFolderName is configured - " + messagesFolderName);
-        phraseAppSyncTask.setMessagesFoldername(messagesFolderName);
-
-        String messageFilePrefix = settings.getMessageFilePrefix();
-        LOG.debug("Config: MessageFilePrefix is configured - " + messageFilePrefix);
-        phraseAppSyncTask.setMessageFilePrefix(messageFilePrefix);
-
-        // TODO - update Client Impl
-        String messageFilePostfix = "." + settings.getFileFormat();
-        LOG.debug("Config: MessageFilePostfix is configured - " + messageFilePostfix);
-        phraseAppSyncTask.setMessageFilePostfix(messageFilePostfix);
-
-        // TODO - fileformat!
-        String fileFormat = settings.getFileFormat();
-        LOG.debug("Config: format is configured - " + fileFormat);
-        phraseAppSyncTask.setFormat(JavaPropertiesFormat.newBuilder().build());
     }
 
 }

--- a/src/test/groovy/de/esailors/gradle/plugins/phraseapp/PhraseAppDownloaderTest.groovy
+++ b/src/test/groovy/de/esailors/gradle/plugins/phraseapp/PhraseAppDownloaderTest.groovy
@@ -1,0 +1,58 @@
+package de.esailors.gradle.plugins.phraseapp
+
+import com.mytaxi.apis.phrase.api.format.Format
+import com.mytaxi.apis.phrase.tasks.PhraseAppSyncTask
+import de.esailors.gradle.plugins.phraseapp.extension.PhraseAppExtension
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotNull
+import static org.mockito.Mockito.*
+
+class PhraseAppDownloaderTest {
+    public static final String AUTH_TOKEN = "authToken"
+    public static final String PROJECT_ID = "projectId"
+
+    private PhraseAppDownloader testDownloader
+    private PhraseAppExtension extension
+    private PhraseAppSyncTask syncTask
+
+    @Before
+    void setUp() throws Exception {
+        syncTask = mock(PhraseAppSyncTask.class)
+        extension = mock(PhraseAppExtension.class)
+        testDownloader = new PhraseAppDownloader(extension, syncTask)
+    }
+
+    @Test
+    void should_create_sync_task_constructor() {
+        PhraseAppExtension extension = new PhraseAppExtension()
+        extension.setAuthToken(AUTH_TOKEN)
+        extension.setProjectId(PROJECT_ID)
+        PhraseAppDownloader downloader = new PhraseAppDownloader(extension)
+
+        assertNotNull(downloader.phraseAppSyncTask)
+    }
+
+    @Test
+    void should_use_properties_default_format() {
+        when(extension.getFormat()).thenReturn("properties")
+        testDownloader.download()
+
+        ArgumentCaptor<Format> argument = ArgumentCaptor.forClass(Format.class)
+        verify(syncTask).setFormat(argument.capture())
+        assertEquals("properties", argument.getValue().getName())
+    }
+
+    @Test
+    void should_use_configured_format() {
+        when(extension.getFormat()).thenReturn("i18next")
+        testDownloader.download()
+
+        ArgumentCaptor<Format> argument = ArgumentCaptor.forClass(Format.class)
+        verify(syncTask).setFormat(argument.capture())
+        assertEquals("i18next", argument.getValue().getName())
+    }
+}

--- a/src/test/groovy/de/esailors/gradle/plugins/phraseapp/format/OptionlessFormatTest.groovy
+++ b/src/test/groovy/de/esailors/gradle/plugins/phraseapp/format/OptionlessFormatTest.groovy
@@ -1,0 +1,24 @@
+package de.esailors.gradle.plugins.phraseapp.format
+
+import com.mytaxi.apis.phrase.api.format.Format
+import org.junit.Test
+
+import static junit.framework.Assert.assertEquals
+import static junit.framework.Assert.assertTrue
+
+class OptionlessFormatTest {
+
+    @Test
+    void builder_should_return_format_with_name() {
+        Format format = new OptionlessFormat("i18next")
+
+        assertEquals("i18next", format.getName())
+    }
+
+    @Test
+    void should_return_empty_list() {
+        Format format = new OptionlessFormat("i18next")
+
+        assertTrue(format.getOptions().isEmpty())
+    }
+}

--- a/src/test/groovy/de/esailors/gradle/plugins/phraseapp/tasks/DownloadTaskTest.groovy
+++ b/src/test/groovy/de/esailors/gradle/plugins/phraseapp/tasks/DownloadTaskTest.groovy
@@ -1,10 +1,10 @@
-package de.esailors.gradle.plugins.phraseapp
+package de.esailors.gradle.plugins.phraseapp.tasks
 
-import de.esailors.gradle.plugins.phraseapp.tasks.DownloadTask
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
-import static org.junit.Assert.*
+
+import static org.junit.Assert.assertTrue
 
 /**
  * @author m.winkelmann
@@ -12,7 +12,7 @@ import static org.junit.Assert.*
 class DownloadTaskTest {
 
     @Test
-    public void should_be_able_to_add_task_to_project() {
+    void should_be_able_to_add_task_to_project() {
         Project project = ProjectBuilder.builder().build()
         def task = project.task('download', type: DownloadTask)
         assertTrue(task instanceof DownloadTask)


### PR DESCRIPTION
This currently does not work with several formats, e.g. all which returns JSON directly, as the mytaxi PhraseApp api tries to convert all responses as an byte-array, which seems to doesn't work with JSON. However, xml is working pretty fine, which is already an improvement.